### PR TITLE
AAIC-147: remove auto logout, when password is set

### DIFF
--- a/botfront/imports/api/user/user.methods.js
+++ b/botfront/imports/api/user/user.methods.js
@@ -186,7 +186,7 @@ if (Meteor.isServer) {
 
             try {
                 const userBefore = Meteor.users.findOne({ _id: userId });
-                const result = Promise.await(Accounts.setPassword(userId, newPassword));
+                const result = Promise.await(Accounts.setPassword(userId, newPassword, {logout: false}));
                 const userAfter = Meteor.users.findOne({ _id: userId });
                 auditLog('Changed user password', {
                     user: Meteor.user(),


### PR DESCRIPTION
Since meteor 1.0.2 the user account is automatically logged out for which the password has been changed.
This behavior is unexpected in the botfront ui and resulted in a bug, where the ui was not able to function because of missing priviliges.
The solution was as simple as setting `logout: false` in the options parameter of the `setPassword` function call.