### PR TITLE
feat: influence conversation feature to slots

### DIFF
--- a/botfront/imports/api/rest/index.js
+++ b/botfront/imports/api/rest/index.js
@@ -1,8 +1,10 @@
 import express from 'express';
 import fileUpload from 'express-fileupload';
+import { safeLoad, safeDump } from 'js-yaml';
 import utilitiesService from './utilities.service';
 import { createUser } from './users.service';
 import projectsService, { importProject } from './projects.service';
+import { GlobalSettings } from '../globalSettings/globalSettings.collection';
 
 const FILE_SIZE_LIMIT = 1024 * 1024;
 
@@ -14,30 +16,60 @@ export const adminPassword = process.env.ADMIN_PASSWORD;
 // make sure the database hase been initialised completely before creating the user
 setTimeout(() => { createAdminUser(); }, 4000);
 
+async function createGlobalSettings() {
+    const publicSettings = safeLoad(Assets.getText('defaults/public.yaml'));
+    const privateSettings = safeLoad(Assets.getText(
+        process.env.MODE === 'development'
+            ? 'defaults/private.dev.yaml'
+            : process.env.ORCHESTRATOR === 'gke' ? 'defaults/private.gke.yaml' : 'defaults/private.yaml',
+    ));
+
+    const settings = {
+        public: {
+            backgroundImages: publicSettings.backgroundImages || [],
+            defaultNLUConfig: safeDump({ pipeline: publicSettings.pipeline }),
+        },
+        private: {
+            bfApiHost: privateSettings.bfApiHost || '',
+            defaultEndpoints: safeDump(privateSettings.endpoints),
+            defaultCredentials: safeDump(privateSettings.credentials)
+                .replace(/{SOCKET_HOST}/g, process.env.SOCKET_HOST || 'botfront.io'),
+            defaultPolicies: safeDump({ policies: privateSettings.policies }),
+            defaultDefaultDomain: safeDump(privateSettings.defaultDomain),
+            webhooks: privateSettings.webhooks,
+        },
+    };
+    await GlobalSettings.insert({ _id: 'SETTINGS', settings });
+}
+
 async function createAdminUser() {
-  // create admin on startup
-  if (adminEmail != null && adminPassword != null) {
-    try {
-      await createUser({
-        email: adminEmail,
-        roles: [{ roles: ['global-admin'], project: 'GLOBAL' }],
-        profile: { firstName: 'admin', lastName: 'admin', preferredLanguage: 'en' }
-      }, adminPassword);
-    } catch (error) {
+    // create admin on startup
+    if (adminEmail != null && adminPassword != null) {
+        try {
+            await createUser({
+                email: adminEmail,
+                roles: [{ roles: ['global-admin'], project: 'GLOBAL' }],
+                profile: { firstName: 'admin', lastName: 'admin', preferredLanguage: 'en' },
+            }, adminPassword);
+        } catch (error) {
+        }
+        const currentGlobalSettings = GlobalSettings.findOne({ _id: 'SETTINGS' });
+        if (currentGlobalSettings == null) {
+            await createGlobalSettings();
+        }
     }
-  }
 }
 
 const app = express();
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use(fileUpload({
-  limits: { fileSize: FILE_SIZE_LIMIT },
+    limits: { fileSize: FILE_SIZE_LIMIT },
 }));
 
 app.get('/api', (req, res, next) => {
-  res.sendStatus(200);
-})
+    res.sendStatus(200);
+});
 
 /**
  * @swagger
@@ -59,34 +91,34 @@ app.get('/api', (req, res, next) => {
             preferredLanguage: string'
           }
         }
- *     
+ *
 */
-app.put('/api/users', utilitiesService.authMW(restApiToken), async(req, res, next) => {
-  const inputs = req.body;
+app.put('/api/users', utilitiesService.authMW(restApiToken), async (req, res, next) => {
+    const inputs = req.body;
 
-  if (inputs.email == null || inputs.password == null) {
-    res.status(400).send('Missing email or password');
-    return;
-  }
+    if (inputs.email == null || inputs.password == null) {
+        res.status(400).send('Missing email or password');
+        return;
+    }
 
-  if (inputs.roles != null && (!Array.isArray(inputs.roles) || inputs.roles.length < 1)) {
-    res.status(400).send({ error: 'Malformed or missing roles' });
-    return;
-  }
+    if (inputs.roles != null && (!Array.isArray(inputs.roles) || inputs.roles.length < 1)) {
+        res.status(400).send({ error: 'Malformed or missing roles' });
+        return;
+    }
 
-  const user = {
-    email: inputs.email,
-    roles: inputs.roles ?? [{ roles: ['global-admin'], project: 'GLOBAL' }],
-    profile: inputs.profile ?? { firstName: 'generated', 'lastName': 'generated', preferredLanguage: 'en' }
-  };
+    const user = {
+        email: inputs.email,
+        roles: inputs.roles ?? [{ roles: ['global-admin'], project: 'GLOBAL' }],
+        profile: inputs.profile ?? { firstName: 'generated', lastName: 'generated', preferredLanguage: 'en' },
+    };
 
-  try {
-    const success = await createUser(user, inputs.password);
-    res.send(success);
-  } catch (error) {
-    console.log({ error });
-    res.status(500).send({ error });
-  }
+    try {
+        const success = await createUser(user, inputs.password);
+        res.send(success);
+    } catch (error) {
+        console.log({ error });
+        res.status(500).send({ error });
+    }
 });
 
 
@@ -101,35 +133,34 @@ app.put('/api/users', utilitiesService.authMW(restApiToken), async(req, res, nex
           baseUrl: string; // the url under which the rasa bot instance is reachable
           projectId?: string // OPTIONAL, the projectId  used for creating the project
         }
- *     
+ *
 */
 app.put('/api/projects', utilitiesService.authMW(restApiToken), async (req, res, next) => {
-  const inputs = req.body;
+    const inputs = req.body;
 
-  if (inputs.name == null || typeof inputs.name !== 'string' || inputs.name.match(/^[a-zA-Z0-9]+$/) == null
+    if (inputs.name == null || typeof inputs.name !== 'string' || inputs.name.match(/^[a-zA-Z0-9]+$/) == null
     || inputs.nameSpace == null || typeof inputs.nameSpace !== 'string' || inputs.nameSpace.match(/^bf-[a-zA-Z0-9-]+$/) == null
     || inputs.baseUrl == null || typeof inputs.baseUrl !== 'string' || inputs.baseUrl.match(/^(http|https):\/\//) == null
     || (inputs.projectId != null && (typeof inputs.projectId !== 'string' || inputs.projectId.length < 1))
-  ) {
-    res.status(400).send('Malformed or missing inputs');
-    return;
-  }
-
-  try {
-    const projectId = await projectsService.createProject(inputs.name, inputs.nameSpace, inputs.baseUrl, inputs.projectId);
-
-    if (projectId == null) {
-      res.send({ projectId, alreadyExists: true });
-      return;
+    ) {
+        res.status(400).send('Malformed or missing inputs');
+        return;
     }
 
-    res.send({ projectId });
-  } catch (error) {
-    console.log({ error });
-    res.status(500).send({ error });
-  }
-});
+    try {
+        const projectId = await projectsService.createProject(inputs.name, inputs.nameSpace, inputs.baseUrl, inputs.projectId);
 
+        if (projectId == null) {
+            res.send({ projectId, alreadyExists: true });
+            return;
+        }
+
+        res.send({ projectId });
+    } catch (error) {
+        console.log({ error });
+        res.status(500).send({ error });
+    }
+});
 
 
 /**
@@ -142,38 +173,38 @@ app.put('/api/projects', utilitiesService.authMW(restApiToken), async (req, res,
           file: blob; // a single zip file containing all required files
           projectId: string // the projectId used for importing into a project
         }
- *     
+ *
 */
 app.post('/api/projects/import', utilitiesService.authMW(restApiToken), async (req, res, next) => {
-  if (req.body.projectId == null || req.body.projectId.length < 1) {
-    res.status(400).send({ error: 'Provide a projectId' });
-    return;
-  }
-
-  const projectId = req.body.projectId;
-
-  if (req.files?.file == null || req.files.file.mimetype !== 'application/zip') {
-    res.status(400).send({ error: 'Send exactly one zip file' });
-    return;
-  }
-
-  const file = req.files.file.data;
-
-  try {
-    const result = await importProject(file, projectId);
-
-    if (result.errors != null) {
-      throw new Error(JSON.stringify(result));
+    if (req.body.projectId == null || req.body.projectId.length < 1) {
+        res.status(400).send({ error: 'Provide a projectId' });
+        return;
     }
 
-    res.send({ projectId });
-  } catch (error) {
-    const statusCode = error.statusCode || 500;
-    res.status(statusCode).send({ error: error.message });
-  }
+    const { projectId } = req.body;
+
+    if (req.files?.file == null || req.files.file.mimetype !== 'application/zip') {
+        res.status(400).send({ error: 'Send exactly one zip file' });
+        return;
+    }
+
+    const file = req.files.file.data;
+
+    try {
+        const result = await importProject(file, projectId);
+
+        if (result.errors != null) {
+            throw new Error(JSON.stringify(result));
+        }
+
+        res.send({ projectId });
+    } catch (error) {
+        const statusCode = error.statusCode || 500;
+        res.status(statusCode).send({ error: error.message });
+    }
 });
 
 
 app.listen(port, () => {
-  console.log(`REST API listening at port: ${port}`);
-})
+    console.log(`REST API listening at port: ${port}`);
+});

--- a/botfront/imports/api/rest/projects.service.js
+++ b/botfront/imports/api/rest/projects.service.js
@@ -185,7 +185,7 @@ function insertProject(item) {
 
     const projectId = Projects.insert({
         ...item,
-        defaultDomain: { content: 'slots:\n  disambiguation_message:\n    type: any\nactions:\n  - action_botfront_disambiguation\n  - action_botfront_disambiguation_followup\n  - action_botfront_fallback\n  - action_botfront_mapping' },
+        defaultDomain: { content: 'slots:\n  disambiguation_message:\n    type: any\n    influence_conversation: false\nactions:\n  - action_botfront_disambiguation\n  - action_botfront_disambiguation_followup\n  - action_botfront_fallback\n  - action_botfront_mapping' },
         languages: [defaultLanguage],
         chatWidgetSettings: {
             title: item.name,

--- a/botfront/imports/api/slots/slots.schema.js
+++ b/botfront/imports/api/slots/slots.schema.js
@@ -25,6 +25,7 @@ export const SlotSchema = new SimpleSchema({
             'any',
         ],
     },
+    influenceConversation: { type: Boolean, defaultValue: true, optional: true },
     createdAt: {
         type: Date,
         optional: true,

--- a/botfront/imports/lib/importers/validateDomain.js
+++ b/botfront/imports/lib/importers/validateDomain.js
@@ -285,6 +285,7 @@ const validateADomain = (
         slots.push({
             name,
             type: slot.type,
+            influenceConversation: 'influence_conversation' in slot ? slot.influence_conversation : slot.type !== 'any',
             ...options,
         });
     });

--- a/botfront/imports/lib/story.utils.js
+++ b/botfront/imports/lib/story.utils.js
@@ -28,6 +28,7 @@ const getSlotsInRasaFormat = (slots = []) => {
         if (slot.categories) options.values = slot.categories;
         slotsToAdd[slot.name] = {
             type: slot.type,
+            influence_conversation: slot.influenceConversation,
             ...options,
         };
     });
@@ -242,7 +243,7 @@ export const getFragmentsAndDomain = async (projectId, language, env = 'developm
 
     defaultDomain.slots = {
         ...(defaultDomain.slots || {}),
-        fallback_language: { type: 'any', initial_value: defaultLanguage },
+        fallback_language: { type: 'any', initial_value: defaultLanguage, influence_conversation: false },
     };
     appMethodLogger.debug('Selecting fragment groups');
     const groups = StoryGroups.find(

--- a/botfront/imports/ui/components/stories/SlotEditor.jsx
+++ b/botfront/imports/ui/components/stories/SlotEditor.jsx
@@ -63,6 +63,11 @@ function SlotEditor(props) {
                     </>
                 )}
                 {type === 'categorical' && <AutoField name='categories' />}
+                {type !== 'any' && (
+                    <AutoField
+                        name='influenceConversation'
+                    />
+                )}
                 <AutoField
                     name='projectId'
                     value={projectId}

--- a/botfront/imports/ui/components/stories/Slots.jsx
+++ b/botfront/imports/ui/components/stories/Slots.jsx
@@ -41,6 +41,7 @@ class Slots extends React.Component {
         this.setState({
             newSlot: {
                 type: slotType,
+                influenceConversation: slotType !== 'any', // set false for any type slots (as in rasa docs)
             },
         });
     };

--- a/botfront/private/defaults/private.dev.yaml
+++ b/botfront/private/defaults/private.dev.yaml
@@ -26,6 +26,7 @@ defaultDomain:
   slots:
     disambiguation_message:
       type: any
+      influence_conversation: false
   actions:
     - action_botfront_disambiguation
     - action_botfront_disambiguation_followup

--- a/botfront/private/defaults/private.gke.yaml
+++ b/botfront/private/defaults/private.gke.yaml
@@ -26,6 +26,7 @@ defaultDomain:
   slots:
     disambiguation_message:
       type: any
+      influence_conversation: false
   actions:
     - action_botfront_disambiguation
     - action_botfront_disambiguation_followup

--- a/botfront/private/defaults/private.yaml
+++ b/botfront/private/defaults/private.yaml
@@ -26,6 +26,7 @@ defaultDomain:
   slots:
     disambiguation_message:
       type: any
+      influence_conversation: false
   actions:
     - action_botfront_disambiguation
     - action_botfront_disambiguation_followup


### PR DESCRIPTION
- Added Rasa's slot influence conversation true/false option to Botfront slot menu: https://rasa.com/docs/rasa/domain/#slots-and-conversation-behavior
- Influence conversation option also gets exported/imported in Botfront and sent to Rasa for training
- Also fixed issue when starting Botfront first time with empty Mongo in local dev mode and global settings were not created