### PR TITLE
fix: graphql-upload for node14

### DIFF
--- a/botfront/imports/api/graphql/index.js
+++ b/botfront/imports/api/graphql/index.js
@@ -1,5 +1,6 @@
 import { mergeTypeDefs } from '@graphql-tools/merge';
 import gql from 'graphql-tag';
+import { GraphQLUpload } from 'graphql-upload-minimal';
 import conversationResolvers from './conversations/resolvers';
 import conversationTypes from './conversations/schemas';
 import activityResolver from './activity/resolvers/activityResolver';
@@ -38,6 +39,7 @@ export const resolvers = [
     analyticsDashboardResolver,
     examplesResolver,
     projectResolver,
+    { Upload: GraphQLUpload },
 ];
 
 const typeList = [
@@ -53,6 +55,7 @@ const typeList = [
     storiesTypes,
     analyticsDashboardTypes,
     projectTypes,
+    gql`scalar Upload`,
 ];
 
 export const typeDefs = mergeTypeDefs(typeList, { all: true });

--- a/botfront/package-lock.json
+++ b/botfront/package-lock.json
@@ -15054,14 +15054,14 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
@@ -16407,6 +16407,14 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.1.tgz",
       "integrity": "sha512-1lPkUXQ2L8o+ERLzVAuc3rzc/E6pGF+6HnjihCVTK0VzR0jCuUd92FqNxoHdfILXqOn2L6b4y47TBxiPyieUVA=="
+    },
+    "graphql-upload-minimal": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload-minimal/-/graphql-upload-minimal-1.3.0.tgz",
+      "integrity": "sha512-Q1esVQfXngc5uTealQ8yr5dE4t8FKt+9jsDQfrybrlYhsc3pmuyYIhHJ+G3KMLZkKbh7D0StfbnQ9/NVqgbcxg==",
+      "requires": {
+        "busboy": "^0.3.1"
+      }
     },
     "gtoken": {
       "version": "5.2.1",

--- a/botfront/package.json
+++ b/botfront/package.json
@@ -63,6 +63,7 @@
     "graphql-scalars": "^1.1.5",
     "graphql-tag": "^2.11.0",
     "graphql-type-json": "^0.3.1",
+    "graphql-upload-minimal": "^1.3.0",
     "immutable": "^3.6.2",
     "js-yaml": "^3.13.1",
     "jszip": "^3.2.2",


### PR DESCRIPTION
- use `graphql-upload-minimal` for graphql uploads in node14 so botfront project import works
