### PR TITLE
fix: add empty deps to useTracker to avoid unnecessary model loading

### DIFF
--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -59,7 +59,7 @@ function NLUModel(props) {
     const { model } = useTracker(() => {
         Meteor.subscribe('nlu_models', projectId);
         return { model: NLUModels.findOne({ projectId, language: workingLanguage }) };
-    });
+    }, []);
 
     const [filters, setFilters] = useState({ sortKey: 'intent', order: 'ASC' });
     const variables = useMemo(() => ({


### PR DESCRIPTION
useTracker without dependencies runs every 10seconds reloading and creating a new model object.
As the model is props input for the child components it triggers rerenders. This results in the reset of any unsaved inputs.

By passing an empty dependency array to the useTracker hook, it triggers only once on first render.
Upon saving the data within the input field an onchange event is triggered, which results in triggering useTracker. So any updates to the data are still reflected on the ui immediately.
