### PR TITLE
fix: entity value can start or end with öäå

### DIFF
--- a/botfront/imports/ui/components/nlu/common/UserUtteranceViewer.jsx
+++ b/botfront/imports/ui/components/nlu/common/UserUtteranceViewer.jsx
@@ -125,7 +125,7 @@ function UserUtteranceViewer(props) {
 
     function adjustBeginning(completeText, anchor) {
         if (anchor === 0 || anchor === completeText.length) return anchor;
-        if (/[\W.,?!;:]/.test(completeText.slice(anchor, anchor + 1))) {
+        if (/(?![äöåÄÖÅ])[\W.,?!;:]/.test(completeText.slice(anchor, anchor + 1))) {
             return adjustBeginning(completeText, anchor + 1);
         }
         if (/[\W.,?!;:][a-zA-Z\u00C0-\u017F0-9-]/.test(
@@ -134,13 +134,13 @@ function UserUtteranceViewer(props) {
         ) {
             return anchor;
         }
-
+        
         return adjustBeginning(completeText, anchor - 1);
     }
 
     function adjustEnd(completeText, extent) {
         if (extent === 0 || extent === completeText.length) return extent;
-        if (/[\W.,?!;:]/.test(completeText.slice(extent - 1, extent))) {
+        if (/(?![äöåÄÖÅ])[\W.,?!;:]/.test(completeText.slice(extent - 1, extent))) {
             return adjustEnd(completeText, extent - 1);
         }
         if (/[a-zA-Z\u00C0-\u017F0-9-][\W.,?!;:]/.test(


### PR DESCRIPTION
- fix botfront to allow entity values start and end with äöåÄÖÅ characters
