### PR TITLE
fix: botfront allows intent and response names to have "/"

### DIFF
--- a/botfront/imports/api/graphql/botResponses/botResponses.model.js
+++ b/botfront/imports/api/graphql/botResponses/botResponses.model.js
@@ -39,7 +39,7 @@ if (Meteor.isServer) {
         key: {
             type: String,
             label: 'Template Key',
-            match: /^utter_[^\s/]*$/, // match utter_ and does not include white spaces
+            match: /^utter_[^\s]*$/, // match utter_ and does not include white spaces
         },
         projectId: {
             type: String,

--- a/botfront/imports/ui/components/nlu/common/IntentLabel.jsx
+++ b/botfront/imports/ui/components/nlu/common/IntentLabel.jsx
@@ -70,7 +70,7 @@ const Intent = React.forwardRef((props, ref) => {
 
     const [selection, setSelection] = useState(dataToDisplay.slice(0, 1).map(i => i.intent));
 
-    const hasInvalidChars = intentName => intentName.match(/[ +/{}/]/);
+    const hasInvalidChars = intentName => intentName.match(/[ +{}]/);
 
     const handleTypeInput = (_e, { value: newInput }) => {
         if (!hasInvalidChars(newInput)) setTypeInput(newInput);


### PR DESCRIPTION
- Botfront allows intent and response names to have "/" character needed in Rasa's ResponseSelector feature
