### PR TITLE
Enable multiple intents in form extraction

### DIFF
--- a/botfront/imports/api/instances/instances.methods.js
+++ b/botfront/imports/api/instances/instances.methods.js
@@ -420,7 +420,7 @@ if (Meteor.isServer) {
                             if (Array.isArray(element[key])) {
                                 if (element[key].length > 0) {
                                     // keep element key value if it is not an empty list
-                                    new_element[key] = element[key][0];
+                                    new_element[key] = element[key];
                                 }
                             } else {
                                 new_element[key] = element[key];


### PR DESCRIPTION
Training data payload for forms is generated and restructured in botfront to shelf-rasa compatible syntax. Old solution did get only first item in slot extraction when using "intent" or "not intent" lists. Now multiple values are enabled.