### PR TITLE
fix: influence conversation for slot requested_slot

### DIFF
--- a/botfront/imports/lib/story.utils.js
+++ b/botfront/imports/lib/story.utils.js
@@ -227,7 +227,7 @@ const addRequestedSlot = async (slots, projectId) => {
         projectId,
         type: 'categorical',
         categories: [...new Set(requestedSlotCategories)],
-        influenceConversation: existingRequestedSlot.influenceConversation,
+        influenceConversation: true,
     };
 
     newSlots.push(requestedSlot);


### PR DESCRIPTION
The requested_slot slot is created in training time if user has enabled contextual side questions form configuration (turns contextual side questions on). Influence conversation must be enabled in that case. (see Rasa documentation: https://rasa.com/docs/rasa/2.x/forms/  in "The requested_slot slot" paragraph.