### PR TITLE
fix: provide projectId props to nlu LookupTable to enable permission …

### DIFF
--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -245,11 +245,21 @@ function NLUModel(props) {
                             },
                             {
                                 menuItem: 'Synonyms',
-                                render: () => <Synonyms model={model} />,
+                                render: () => (
+                                    <Synonyms
+                                        model={model}
+                                        projectId={projectId}
+                                    />
+                                ),
                             },
                             {
                                 menuItem: 'Gazette',
-                                render: () => <Gazette model={model} />,
+                                render: () => (
+                                    <Gazette
+                                        model={model}
+                                        projectId={projectId}
+                                    />
+                                ),
                             },
                             {
                                 menuItem: 'Out Of Scope',
@@ -257,7 +267,12 @@ function NLUModel(props) {
                             },
                             {
                                 menuItem: 'Regex',
-                                render: () => <RegexFeatures model={model} />,
+                                render: () => (
+                                    <RegexFeatures
+                                        model={model}
+                                        projectId={projectId}
+                                    />
+                                ),
                             },
                             {
                                 menuItem: 'API',

--- a/botfront/imports/ui/components/synonyms/RegexFeatures.jsx
+++ b/botfront/imports/ui/components/synonyms/RegexFeatures.jsx
@@ -17,7 +17,7 @@ class RegexFeatures extends React.Component {
     };
 
     render() {
-        const { model } = this.props;
+        const { model, projectId } = this.props;
         return (
             <LookupTable
                 data={model.training_data.regex_features}
@@ -30,12 +30,14 @@ class RegexFeatures extends React.Component {
                 valuePlaceholder='name'
                 listPlaceholder='Enter a regular expression'
                 multiple={false}
+                projectId={projectId}
             />
         );
     }
 }
 
 RegexFeatures.propTypes = {
+    projectId: PropTypes.string.isRequired,
     model: PropTypes.object.isRequired,
 };
 


### PR DESCRIPTION
Within the NLU page, the tabs for synonyms, gazette and regex were missing the projectId props resulting in failing permission check for the inner LookupTable. I added the missing projectId props and the trash bin is now visible.